### PR TITLE
Additional Features - Move Queue items and extended search

### DIFF
--- a/AdvancedTradeSkillWindow/AdvancedTradeSkillWindow.toc
+++ b/AdvancedTradeSkillWindow/AdvancedTradeSkillWindow.toc
@@ -2,7 +2,7 @@
 ## Title: AdvancedTradeSkillWindow
 ## Notes: An improved window for your tradeskills for Vanilla
 ## RequiredDeps:
-## Version: v0.5.8 
+## Version: v0.5.9
 ## SavedVariables: atsw_orderby, atsw_bankitemlist, atsw_merchantlist, atsw_itemlist, atsw_considerbank, atsw_consideralts, atsw_considermerchants, atsw_autobuy, atsw_multicount, atsw_recipetooltip, atsw_customsorting, atsw_customheaders, atsw_displayshoppinglist, atsw_disabled, atsw_savedqueue, atsw_savednecessaryitems
 
 ## X-ReleaseDate: $Date: 2024-11-18 $

--- a/AdvancedTradeSkillWindow/README.txt
+++ b/AdvancedTradeSkillWindow/README.txt
@@ -292,5 +292,8 @@ v0.5.6a
 - Fix errors after RightClick on reagents
 
 v0.5.7
+- No update information provided by author.
+
+v0.5.8
 - Added ability to move queued crafts up and down the queue list
 - Combined searching recipes and reagents into the default search.

--- a/AdvancedTradeSkillWindow/README.txt
+++ b/AdvancedTradeSkillWindow/README.txt
@@ -290,3 +290,7 @@ v0.5.6
 
 v0.5.6a
 - Fix errors after RightClick on reagents
+
+v0.5.7
+- Added ability to move queued crafts up and down the queue list
+- Combined searching recipes and reagents into the default search.

--- a/AdvancedTradeSkillWindow/atsw.lua
+++ b/AdvancedTradeSkillWindow/atsw.lua
@@ -2235,6 +2235,14 @@ function ATSW_Filter(skillname)
 			end
 			]]
 		end
+		-- Added :craft filter to replace original search behavior where only craft recipe names were searched
+		if(parameters[i].name=="craft" or parameters[i].name=="c") then
+			-- Search only recipe names (original behavior)
+			if(string.find(string.lower(skillname),".-"..string.lower(parameters[i].value)..".-")==nil) then
+				return false;
+			end
+		end
+		--
 		if(parameters[i].name=="reagent" or parameters[i].name=="r") then
 			local index=ATSW_GetTradeSkillListPosByName(skillname);
 			if(index~=-1) then
@@ -2434,6 +2442,7 @@ function ATSW_BuildFilterDropDown()
 		[7]	= { ":maxlevel 60",			"Max Level",				":maxlevel [level]",							"Filters the list to only include recipes for items with no more than the given level requirement." },
 		[8]	= { ":maxrarity blue",		"Max Rarity",				":maxrarity [grey|white|green|blue|purple]",	"Filters the list to only include recipes for items with no more than the given rarity." },		
 		[9]	= { ":reagent ",			"Reagents",					":reagent [reagent name]",						"Filters the list to only include items that need the specified reagent." },
+		[10] = {":craft",				"Crating Recipe",			":craft: [recipe name]",						"Filters the list to only include recipes with the specific name"},
 	}
 	
 	for filter, values in ipairs(filters) do

--- a/AdvancedTradeSkillWindow/atsw.lua
+++ b/AdvancedTradeSkillWindow/atsw.lua
@@ -1293,15 +1293,17 @@ function ATSWFrame_UpdateQueue()
 			upButton.jobindex=jobindex;
 			queueItem:Show();
 			queueButton:Show();
+			downButton:Show();
+			upButton:Show();
 			if(jobindex >= jobs) then
-				downButton:Hide();
+				downButton:Disable();
 			else
-				downButton:Show();
+				downButton:Enable();
 			end
 			if(jobindex <= 1) then
-				upButton:Hide();
+				upButton:Disable();
 			else
-				upButton:Show();
+				upButton:Enable();
 			end
 		else
 			queueButton:Hide();

--- a/AdvancedTradeSkillWindow/atsw.lua
+++ b/AdvancedTradeSkillWindow/atsw.lua
@@ -828,6 +828,22 @@ function ATSWSkillButton_OnClick(button)
 	if(button=="LeftButton") then
 		ATSWFrame_SetSelection(this:GetID(),true);
 		ATSWFrame_Update();
+		
+		-- Alt+Click to add 1x to queue
+		if(IsAltKeyDown()) then
+			local skillName, skillType, numAvailable;
+			local listpos=ATSW_GetSkillListingPos(this:GetID());
+			if(atsw_skilllisting[listpos]) then
+				skillName = atsw_skilllisting[listpos].name;
+				skillType = atsw_skilllisting[listpos].type;
+			end
+			
+			-- Only add to queue if it's not a header and has a valid skill name
+			if(skillName and skillType ~= "header") then
+				ATSW_AddJob(skillName, 1);
+				ATSWFrame_UpdateQueue();
+			end
+		end
 	end
 end
 
@@ -2484,7 +2500,7 @@ function ATSW_DisplayTradeskillTooltip()
 		skillType = atsw_skilllisting[listpos].type;
 		else
 		skillName=nil;
-		akillType=nil;
+		skillType=nil;
 	end
 	
 	if(skillName and skillType ~= "header") then
@@ -2515,6 +2531,8 @@ function ATSW_DisplayTradeskillTooltip()
 			end
 		end
 		ATSWTradeskillTooltip:AddLine(ATSW_TOOLTIP_LEGEND);
+		ATSWTradeskillTooltip:AddLine(" ");
+		ATSWTradeskillTooltip:AddLine("Alt+Click to add craft to queue (x1)");
 		
 		ATSWTradeskillTooltip:Show();
 	end

--- a/AdvancedTradeSkillWindow/atsw.lua
+++ b/AdvancedTradeSkillWindow/atsw.lua
@@ -1,4 +1,4 @@
--- Advanced Trade Skill Window v0.5.6a for Vanilla
+-- Advanced Trade Skill Window v0.5.8 for Vanilla 1.12
 -- copyright 2006 by Rene Schneider (Slarti on EU-Blackhand), 2017 by laytya
 
 -- main script file

--- a/AdvancedTradeSkillWindow/atsw.xml
+++ b/AdvancedTradeSkillWindow/atsw.xml
@@ -1639,7 +1639,7 @@
 				</Anchors>
 				<Scripts>
 					<OnClick>
-						ATSW_MoveJobDown(this.jobindex);
+						ATSW_DeleteJob(this.jobindex);
 					</OnClick>
         			<OnEnter>
             			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
@@ -1724,7 +1724,7 @@
 				</Anchors>
 				<Scripts>
 					<OnClick>
-						ATSW_MoveJobDown(this.jobindex);
+						ATSW_DeleteJob(this.jobindex);
 					</OnClick>
         			<OnEnter>
             			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");

--- a/AdvancedTradeSkillWindow/atsw.xml
+++ b/AdvancedTradeSkillWindow/atsw.xml
@@ -1639,10 +1639,68 @@
 				</Anchors>
 				<Scripts>
 					<OnClick>
-						ATSW_DeleteJob(this.jobindex);
+						ATSW_MoveJobDown(this.jobindex);
 					</OnClick>
+        			<OnEnter>
+            			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+            			GameTooltip:SetText("Remove craft from the queue");
+            			GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
 				</Scripts>
 			</Button>
+			<Button name="ATSWQueueItem1DownButton" inherits="UIPanelButtonTemplate" text="D">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem1DeleteButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-11" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobDown(this.jobindex);
+					</OnClick>
+        			<OnEnter>
+            			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+            			GameTooltip:SetText("Move craft down the queue");
+            			GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
+				</Scripts>
+			</Button>
+			<Button name="ATSWQueueItem1UpButton" inherits="UIPanelButtonTemplate" text="U">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem1DownButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-1" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobUp(this.jobindex);
+					</OnClick>
+					<OnEnter>
+						GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+						GameTooltip:SetText("Move craft up the queue");
+						GameTooltip:Show();
+					</OnEnter>
+					<OnLeave>
+						GameTooltip:Hide();
+					</OnLeave>				
+				</Scripts>
+			</Button>			
 
 			<Frame name="ATSWQueueItem2" inherits="ATSWQueueItemButtonTemplate">
 				<Anchors>
@@ -1666,10 +1724,69 @@
 				</Anchors>
 				<Scripts>
 					<OnClick>
-						ATSW_DeleteJob(this.jobindex);
+						ATSW_MoveJobDown(this.jobindex);
 					</OnClick>
+        			<OnEnter>
+            			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+            			GameTooltip:SetText("Remove craft from the queue");
+            			GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
 				</Scripts>
 			</Button>
+			<Button name="ATSWQueueItem2DownButton" inherits="UIPanelButtonTemplate" text="D">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem2DeleteButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-11" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobDown(this.jobindex);
+					</OnClick>
+        			<OnEnter>
+            			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+            			GameTooltip:SetText("Move craft down the queue");
+            			GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
+				</Scripts>
+			</Button>
+			<Button name="ATSWQueueItem2UpButton" inherits="UIPanelButtonTemplate" text="U">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem2DownButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-1" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobUp(this.jobindex);
+					</OnClick>
+					<OnEnter>
+						GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+						GameTooltip:SetText("Move craft up the queue");
+						GameTooltip:Show();
+					</OnEnter>
+					<OnLeave>
+						GameTooltip:Hide();
+					</OnLeave>				
+				</Scripts>
+			</Button>
+
 
 			<Frame name="ATSWQueueItem3" inherits="ATSWQueueItemButtonTemplate">
 				<Anchors>
@@ -1695,8 +1812,66 @@
 					<OnClick>
 						ATSW_DeleteJob(this.jobindex);
 					</OnClick>
+        			<OnEnter>
+						GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+						GameTooltip:SetText("Remove craft from the queue");
+						GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
 				</Scripts>
 			</Button>
+			<Button name="ATSWQueueItem3DownButton" inherits="UIPanelButtonTemplate" text="D">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem3DeleteButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-11" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobDown(this.jobindex);
+					</OnClick>
+        			<OnEnter>
+            			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+            			GameTooltip:SetText("Move craft down the queue");
+            			GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
+				</Scripts>
+			</Button>
+			<Button name="ATSWQueueItem3UpButton" inherits="UIPanelButtonTemplate" text="U">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem3DownButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-1" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobUp(this.jobindex);
+					</OnClick>
+					<OnEnter>
+						GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+						GameTooltip:SetText("Move craft up the queue");
+						GameTooltip:Show();
+					</OnEnter>
+					<OnLeave>
+						GameTooltip:Hide();
+					</OnLeave>				
+				</Scripts>
+			</Button>			
 
 			<Frame name="ATSWQueueItem4" inherits="ATSWQueueItemButtonTemplate">
 				<Anchors>
@@ -1720,10 +1895,68 @@
 				</Anchors>
 				<Scripts>
 					<OnClick>
-						ATSW_DeleteJob(this.jobindex);
+						ATSW_MoveJobDown(this.jobindex);
 					</OnClick>
+        			<OnEnter>
+            			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+            			GameTooltip:SetText("Remove craft from the queue");
+            			GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
 				</Scripts>
 			</Button>
+			<Button name="ATSWQueueItem4DownButton" inherits="UIPanelButtonTemplate" text="D">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem4DeleteButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-11" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobDown(this.jobindex);
+					</OnClick>
+        			<OnEnter>
+            			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+            			GameTooltip:SetText("Move craft down the queue");
+            			GameTooltip:Show();
+        			</OnEnter>
+        			<OnLeave>
+            			GameTooltip:Hide();
+        			</OnLeave>					
+				</Scripts>
+			</Button>			
+			<Button name="ATSWQueueItem4UpButton" inherits="UIPanelButtonTemplate" text="U">
+				<Size>
+					<AbsDimension x="20" y="22"/>
+				</Size>
+				<Anchors>
+					<Anchor point="RIGHT" relativeTo="ATSWQueueItem4DownButton" relativePoint="LEFT">
+						<Offset>
+							<AbsDimension x="-1" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnClick>
+						ATSW_MoveJobUp(this.jobindex);
+					</OnClick>
+					<OnEnter>
+						GameTooltip:SetOwner(this, "ANCHOR_RIGHT");
+						GameTooltip:SetText("Move craft up the queue");
+						GameTooltip:Show();
+					</OnEnter>
+					<OnLeave>
+						GameTooltip:Hide();
+					</OnLeave>				
+				</Scripts>
+			</Button>			
 
 			<ScrollFrame name="ATSWQueueScrollFrame" inherits="ATSWQueueScrollFrameTemplate">
 				<Size>

--- a/AdvancedTradeSkillWindow/atsw.xml
+++ b/AdvancedTradeSkillWindow/atsw.xml
@@ -1895,7 +1895,7 @@
 				</Anchors>
 				<Scripts>
 					<OnClick>
-						ATSW_MoveJobDown(this.jobindex);
+						ATSW_DeleteJob(this.jobindex);
 					</OnClick>
         			<OnEnter>
             			GameTooltip:SetOwner(this, "ANCHOR_RIGHT");

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ of "green".
 
 
 ## Changelog:
+v0.5.8
+- Added ability to move queued crafts up and down the list
+- Alt left click will add x1 craft of that item to the queue
+- Changed default search behavior to search recipe names and reagents
+- added :craft predefined filter to replace original search functionality (searches crafted item names only)
+
 v0.5.7
 - Fix for scroll jumps
 - Added presets for easy filter select


### PR DESCRIPTION
This update adds the ability to move items up and down the crafting queue.  The default search also now shows results where either the recipe name OR reagent matches. For example, as an alchemist and searching "dream" will show recipes such as Dreamshard Elixir and also anything that needs a Dreamfoil to create.

Because of the change in default search behaviour, I've added another filter :craft which functions like the original search function

Readme and TOC version also updated.